### PR TITLE
feat: auto-discovery for APIRouters, stale file cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,46 @@ export const get_user = async (
 
 
 ---
+## Auto-Discovery
+
+FluidKit can automatically discover and bind APIRouters from files with the `+` prefix - inspired by SvelteKit's convention for special files. This enables **co-location** where your API logic sits next to your frontend routes, eliminating manual router imports and keeping related code together.
+
+**Create discoverable API files:**
+```python
+# routes/users/+api.py
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()  # Any variable name works
+
+class User(BaseModel):
+    id: int
+    name: str
+
+@router.get("/users/{user_id}")
+async def get_user(user_id: int) -> User:
+    return User(id=user_id, name="John")
+```
+
+**Enable auto-discovery:**
+```json
+{
+  "autoDiscovery": {
+    "enabled": true,
+    "filePattern": "+*.py"
+  }
+}
+```
+
+**Benefits:**
+
+- ✅ **Zero boilerplate** - No manual router imports
+- ✅ **File co-location** - Place `+server.py` next to your frontend routes
+- ✅ **Flexible naming** - Any APIRouter variable name works
+- ✅ **Predictable routing** - Same behavior as manual `app.include_router()`
+
+
+---
 ##  Full-Stack Development
 Inspired by [Next.js server actions](https://nextjs.org/docs/14/app/building-your-application/data-fetching/server-actions-and-mutations) and [Svelte's remote functions proposal](https://github.com/sveltejs/kit/discussions/13897), FluidKit enables cross-language full-stack development without restrictions.
 
@@ -135,6 +175,7 @@ FluidKit behavior is controlled by `fluid.config.json`:
 
 ```json
 {
+  "framework": null,                 // "sveltekit" | "nextjs" for full-stack
   "target": "development",           // Which environment to build for
   "output": {
     "strategy": "mirror",            // File placement strategy
@@ -153,7 +194,20 @@ FluidKit behavior is controlled by `fluid.config.json`:
       "mode": "separate",
       "apiUrl": "https://api.example.com"
     }
-  }
+  },
+
+  "include": [                       // Auto-discovery scan paths
+    "src/**/*.py",
+    "lib/**/*.py"
+  ],
+  "exclude": [                       // Exclude patterns
+    "**/__pycache__/**",
+    "**/*.test.py"
+  ],
+  "autoDiscovery": {
+    "enabled": false,                // Enable +*.py auto-discovery
+    "filePattern": "+*.py"           // File pattern to scan
+  },
 }
 ```
 
@@ -166,6 +220,11 @@ FluidKit behavior is controlled by `fluid.config.json`:
 | `output.location` | `".fluidkit"` \| `"src/lib"` | Directory for runtime.ts and mirror structure |
 | `mode` | `"unified"` \| `"separate"` | Same codebase vs separate frontend/backend repos |
 | `framework` | `"sveltekit"` \| `"nextjs"` | Enable full-stack integration |
+| `include` | `["src/**/*.py"]` | Paths to scan for auto-discovery |
+| `exclude` | `["**/*.test.py"]` | Patterns to exclude from scanning |
+| `autoDiscovery.enabled` | `true` \| `false` | Enable `+*.py` auto-discovery |
+| `autoDiscovery.filePattern` | `"+*.py"` | File pattern for auto-discovery |
+
 
 **Mode Explanation:**
 - **`"unified"`**: Frontend and backend in same codebase (full-stack apps)

--- a/fluidkit/__init__.py
+++ b/fluidkit/__init__.py
@@ -2,8 +2,6 @@
 FluidKit - Automatic TypeScript client code generation for FastAPI
 """
 
-__version__ = "2.0.0"
-
 def _check_dependencies():
     """Check for required dependencies"""
     missing = []
@@ -30,8 +28,11 @@ def _check_dependencies():
 _check_dependencies()
 
 # Import main API only after dependency check
+from .core.config import get_version
 from .core.schema import LanguageType
 from .core.integrator import integrate, introspect_only, generate_only
+
+__version__ = get_version()
 
 __all__ = [
     # Main functions

--- a/fluidkit/core/autodiscovery.py
+++ b/fluidkit/core/autodiscovery.py
@@ -1,0 +1,276 @@
+"""
+FluidKit Auto-Discovery System
+
+Discovers +*.py files and automatically binds their APIRouters to FastAPI app.
+"""
+
+import sys
+import hashlib
+import importlib.util
+from pathlib import Path
+from typing import List, Tuple, Dict, Any
+from fnmatch import fnmatch
+from fastapi import FastAPI, APIRouter
+
+from fluidkit.core.config import FluidKitConfig
+
+
+def auto_discover_and_bind_routes(app: FastAPI, config: FluidKitConfig, project_root: str, verbose: bool = False) -> List[Dict[str, Any]]:
+    """
+    Auto-discover +*.py files and bind their APIRouters to FastAPI app.
+    
+    Args:
+        app: FastAPI application instance
+        config: FluidKit configuration
+        project_root: Project root directory
+        verbose: Enable detailed logging
+        
+    Returns:
+        List of discovery info dictionaries
+    """
+    if not config.autoDiscovery.enabled:
+        if verbose:
+            print("Auto-discovery disabled in config")
+        return []
+    
+    project_path = Path(project_root).resolve()
+    discovered_files = _find_autodiscovery_files(project_path, config, verbose)
+    
+    discovery_results = []
+    
+    for file_path in discovered_files:
+        try:
+            # Import the module dynamically
+            module, module_name = _import_file_as_module(file_path, project_path)
+            
+            # Find APIRouter instances
+            routers = _find_routers_in_module(module)
+            
+            if not routers:
+                if verbose:
+                    print(f"⚠️ No APIRouters found in {file_path}")
+                continue
+            
+            # Bind each router to FastAPI app (no prefix - predictable behavior)
+            for router_var_name, router_instance in routers:
+                app.include_router(router_instance)  # No prefix
+                
+                discovery_results.append({
+                    "file": str(file_path),
+                    "module_name": module_name,
+                    "router_var": router_var_name,
+                    "routes": len(router_instance.routes)
+                })
+                
+                if verbose:
+                    print(f"✅ Bound {router_var_name} from {file_path} ({len(router_instance.routes)} routes)")
+        
+        except Exception as e:
+            if verbose:
+                print(f"❌ Failed to import {file_path}: {e}")
+            continue
+    
+    if discovery_results and not verbose:
+        total_routers = len(discovery_results)
+        total_routes = sum(r["routes"] for r in discovery_results)
+        print(f"FluidKit: Auto-discovered {total_routers} routers with {total_routes} routes")
+    
+    return discovery_results
+
+
+def _find_autodiscovery_files(project_path: Path, config: FluidKitConfig, verbose: bool = False) -> List[Path]:
+    """Find files matching auto-discovery patterns."""
+    candidates = []
+    
+    # Find files matching include patterns
+    for include_pattern in config.include:
+        if include_pattern.startswith('/'):
+            # Absolute pattern
+            search_path = Path(include_pattern[1:])
+        else:
+            # Relative to project root
+            search_path = project_path / include_pattern
+        
+        # Handle glob patterns
+        if '*' in str(search_path):
+            # Extract base path and pattern
+            parts = search_path.parts
+            base_parts = []
+            pattern_parts = []
+            found_wildcard = False
+            
+            for part in parts:
+                if '*' in part or found_wildcard:
+                    found_wildcard = True
+                    pattern_parts.append(part)
+                else:
+                    base_parts.append(part)
+            
+            if base_parts:
+                base_path = Path(*base_parts)
+            else:
+                base_path = project_path
+            
+            if base_path.exists():
+                pattern = '/'.join(pattern_parts) if pattern_parts else '**/*.py'
+                
+                # Use rglob for recursive patterns
+                if '**' in pattern:
+                    for file_path in base_path.rglob(pattern.replace('**/', '')):
+                        if file_path.suffix == '.py':
+                            candidates.append(file_path)
+                else:
+                    for file_path in base_path.glob(pattern):
+                        if file_path.suffix == '.py':
+                            candidates.append(file_path)
+        else:
+            # Direct path
+            if search_path.exists() and search_path.suffix == '.py':
+                candidates.append(search_path)
+    
+    # Filter by auto-discovery file pattern
+    pattern_matched = []
+    for file_path in candidates:
+        if fnmatch(file_path.name, config.autoDiscovery.filePattern):
+            pattern_matched.append(file_path)
+    
+    # Apply exclude patterns
+    filtered_files = []
+    for file_path in pattern_matched:
+        excluded = False
+        
+        try:
+            relative_path = str(file_path.relative_to(project_path))
+        except ValueError:
+            relative_path = str(file_path)
+        
+        for exclude_pattern in config.exclude:
+            if fnmatch(relative_path, exclude_pattern) or fnmatch(file_path.name, exclude_pattern):
+                excluded = True
+                break
+        
+        if not excluded:
+            filtered_files.append(file_path)
+    
+    if verbose and filtered_files:
+        print(f"Found {len(filtered_files)} auto-discovery files:")
+        for file_path in filtered_files:
+            print(f"  {file_path}")
+    
+    return filtered_files
+
+
+def _import_file_as_module(file_path: Path, project_path: Path) -> Tuple[Any, str]:
+    """Import Python file as module with readable unique name."""
+    module_name = _file_path_to_module_name(file_path, project_path)
+    
+    # Check if already loaded (avoid re-import)
+    if module_name in sys.modules:
+        return sys.modules[module_name], module_name
+    
+    # Dynamic import
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None:
+        raise ImportError(f"Could not create spec for {file_path}")
+    
+    module = importlib.util.module_from_spec(spec)
+    
+    # Add metadata for debugging
+    module.__fluidkit_source__ = str(file_path)
+    module.__fluidkit_hash__ = module_name.split('.')[-1]
+    
+    # Register and execute
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    
+    return module, module_name
+
+
+def _file_path_to_module_name(file_path: Path, project_path: Path) -> str:
+    """Convert file path to readable, unique, consistent module name."""
+    import re
+    
+    # Get relative path
+    try:
+        rel_path = file_path.relative_to(project_path)
+    except ValueError:
+        rel_path = file_path
+    
+    # Remove extension
+    path_without_ext = rel_path.with_suffix('')
+    
+    # Sanitize each part
+    sanitized_parts = []
+    for part in path_without_ext.parts:
+        # Remove special characters, keep alphanumeric
+        clean_part = re.sub(r'[^\w]', '', part)  # Remove [, ], (, ), +, etc.
+        
+        # Ensure starts with letter if it starts with digit
+        if clean_part and clean_part[0].isdigit():
+            clean_part = f"m{clean_part}"
+        
+        if clean_part:  # Only add non-empty parts
+            sanitized_parts.append(clean_part.lower())
+    
+    # Create base module name
+    base_name = '.'.join(sanitized_parts) if sanitized_parts else 'unknown'
+    
+    # Generate consistent hash from original path
+    original_path_str = str(rel_path)
+    path_hash = hashlib.md5(original_path_str.encode()).hexdigest()[:8]
+    
+    # Combine: fluidkit.readable.name.hash
+    return f"fluidkit.{base_name}.{path_hash}"
+
+
+def _find_routers_in_module(module) -> List[Tuple[str, APIRouter]]:
+    """Find all APIRouter instances in a module."""
+    routers = []
+    for attr_name in dir(module):
+        if not attr_name.startswith('_'):  # Skip private attributes
+            try:
+                attr_value = getattr(module, attr_name)
+                if isinstance(attr_value, APIRouter):
+                    routers.append((attr_name, attr_value))
+            except Exception:
+                # Skip attributes that can't be accessed
+                continue
+    return routers
+
+
+# === TESTING HELPERS === #
+
+def test_autodiscovery():
+    """Test the auto-discovery system."""
+    from fastapi import FastAPI
+    from fluidkit.core.config import FluidKitConfig, AutoDiscoveryConfig
+    
+    print("=== TESTING AUTO-DISCOVERY ===")
+    
+    app = FastAPI()
+    
+    # Test config with auto-discovery enabled
+    config = FluidKitConfig()
+    config.autoDiscovery = AutoDiscoveryConfig(enabled=True, filePattern="+*.py")
+    config.include = ["src/**/*.py", "test/**/*.py"]
+    
+    project_root = str(Path.cwd())
+    
+    print(f"Testing auto-discovery in: {project_root}")
+    print(f"Include patterns: {config.include}")
+    print(f"File pattern: {config.autoDiscovery.filePattern}")
+    
+    # Run auto-discovery
+    results = auto_discover_and_bind_routes(app, config, project_root, verbose=True)
+    
+    print(f"\nDiscovery results: {len(results)} routers found")
+    for result in results:
+        print(f"  {result['file']} -> {result['router_var']} ({result['routes']} routes)")
+    
+    print(f"\nTotal FastAPI routes after auto-discovery: {len(app.routes)}")
+    
+    print("\n✅ Auto-discovery test completed!")
+
+
+if __name__ == "__main__":
+    test_autodiscovery()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fluidkit"
-version = "0.1.3"
+version = "0.2.0"
 description = "Automatic TypeScript client generation for FastAPI through runtime introspection"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -27,8 +27,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-dependencies = [
-]
+dependencies = []
 
 [project.optional-dependencies]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -153,7 +153,7 @@ wheels = [
 
 [[package]]
 name = "fluidkit"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Fluidkit can now autodiscover special .py files starting with `+` it follows sveltekit special file convention. this allows to write co-located router file in unconventional non-importable folder structurings such as:

```
routes/
  users/
     [id]/
        +server.py
```
we scan for such files and include them to routes 

fluidkit can now cleanup stale generated files as well
